### PR TITLE
Fix `result` pattern in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 bin/
 tmp-protoc/
 .direnv/
-/result/
+/result


### PR DESCRIPTION
It's a simlink so it shouldn't end with a trailiing slash.
